### PR TITLE
Add documentation of tables to SCB() documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SCBHandlerPlotter
 Title: Handle and Plot SCB Data
-Version: 0.9.0
+Version: 0.9.0.9000
 Authors@R: 
     person(given = "Vilhelm",
            family = "Agdur",

--- a/R/SCB.r
+++ b/R/SCB.r
@@ -35,6 +35,7 @@
 #' SCB(Municipality = "Lomma", LandUseType = "Total forest")
 #' @returns A numeric value. What this value represents can vary greatly by your specific query -- it could be anything from an amount of people to a tax rate to an area of land.
 #'
+#' @seealso The available tables are documented at: AgeGender, BirthRegion, EducationLevel, MunicipalIncomeStatements, HighSchoolEligibility, HouseholdSize, HousingForm, Incomes, LandUse, MaritalStatus, TaxRates.
 #' @export
 SCB <- function(verbose = FALSE, forceTable = NA_character_, failIfUnable = FALSE, collisionHandlingMode = "error", ...) { # All the juice is of course in the innocuous-looking "..."
   # So we have received a query. There are two cases: Either forceTable is set, in which case we just funnel the query

--- a/R/plotOnMap.r
+++ b/R/plotOnMap.r
@@ -68,6 +68,8 @@ fillOutMapPlotFrame <- function(dat) {
 #' girafe(ggobj = plotOnMap(exampledata))
 #' @returns A ggplot object that can be turned into an interactive graphic with the girafe function, see the example.
 #'
+#' @seealso exampleForestPlot
+#'
 #' @export
 
 plotOnMap <- function(dat, tooltips = NA, mainTitle = NA, subTitle = NA, legendTitle = "") {
@@ -245,6 +247,9 @@ plotOnMap <- function(dat, tooltips = NA, mainTitle = NA, subTitle = NA, legendT
 #' library(ggplot2)
 #' library(ggiraph)
 #' girafe(ggobj = exampleForestPlot())
+#'
+#' @seealso plotOnMap
+#'
 #' @export
 
 exampleForestPlot <- function() {

--- a/R/releaseQuestions.r
+++ b/R/releaseQuestions.r
@@ -1,0 +1,6 @@
+release_questions <- function() {
+  c(
+    "Have you run writeTextDocumentation to update table documentation?",
+    "Have you added the @seealso outputted by writeTextDocumentation to the SCB() Roxygen block?"
+  )
+}

--- a/R/writeTextDocumentation.r
+++ b/R/writeTextDocumentation.r
@@ -116,12 +116,14 @@ writeTextDocumentation <- function(filename) {
 
 
 # This function takes as argument the folder where the XML documentation is stored and the folder where the .Rd documentation should be stored.
-# It then runs writeTextDocumentation on each XML file in sourceFolder, and writes the result to targetFolder as an .Rd file.
+# It then runs writeTextDocumentation on each XML file in sourceFolder, and writes the result to targetFolder as an .Rd file. It also writes
+# out a line to manually add to the Roxygen documentation of SCB(), since this seems to be the easiest way to deal with this issue.
 writeAllTextDocumentation <- function(sourceFolder, targetFolder) {
   # Find all the XML files:
   xmlFilesInSourceFolder <- list.files(sourceFolder, pattern="*\\.xml$")
   # We also need these with .Rd as their file extension, since we need to save them:
   filenamesWithRdExtension <- gsub("\\.xml","\\.Rd",xmlFilesInSourceFolder)
+
   # Now we loop over the files and print each of them to the target folder:
   for (fileIndex in c(1:length(xmlFilesInSourceFolder))) {
     targetFilePath <- paste(targetFolder,"/",filenamesWithRdExtension[fileIndex],sep="")
@@ -138,4 +140,10 @@ writeAllTextDocumentation <- function(sourceFolder, targetFolder) {
     close(fileConn)
     message(paste("Wrote documentation based on",xmlFilesInSourceFolder[fileIndex]))
   }
+
+  # Finally, we create the seealso tag needed in SCB() to give a list of the tables:
+  seeAlsoBlock <- paste("@seealso The available tables are documented at: ", paste(loadedTableNames, collapse=", "), ".", sep="")
+  message(paste("Add the following line to the end of the SCB() Roxygen documentation, replacing the old @seealso:\n",seeAlsoBlock,sep=""))
 }
+# If you are in the main library folder, the above function can be run as:
+# writeAllTextDocumentation("./inst/extdata","./man")

--- a/man/SCB.Rd
+++ b/man/SCB.Rd
@@ -56,3 +56,6 @@ SCB(Municipality = "Uppsala", Age=24, Gender="Women", MaritalStatus = "Divorced"
 # How much forest was there in Lomma municipality in 2015?
 SCB(Municipality = "Lomma", LandUseType = "Total forest")
 }
+\seealso{
+The available tables are documented at: AgeGender, BirthRegion, EducationLevel, MunicipalIncomeStatements, HighSchoolEligibility, HouseholdSize, HousingForm, Incomes, LandUse, MaritalStatus, TaxRates.
+}

--- a/man/exampleForestPlot.Rd
+++ b/man/exampleForestPlot.Rd
@@ -15,4 +15,8 @@ forests.
 library(ggplot2)
 library(ggiraph)
 girafe(ggobj = exampleForestPlot())
+
+}
+\seealso{
+plotOnMap
 }

--- a/man/plotOnMap.Rd
+++ b/man/plotOnMap.Rd
@@ -34,3 +34,6 @@ exampledata <- data.frame(municipality = c("Stockholm", "Lund", "Uppsala"),
                           students = c("some", "many", "loads"))
 girafe(ggobj = plotOnMap(exampledata))
 }
+\seealso{
+exampleForestPlot
+}


### PR DESCRIPTION
These changes add a list of the names of the available tables to the documentation of the SCB function. This seems very necessary to make the library practically useful. This resolves issue #5 .

They also add crossreferences between plotOnMap and exampleForestPlot in their documentation, which is nice but perhaps less mandatory.