### PR TITLE
Improve vectorSCB speed and structure

### DIFF
--- a/R/DocumentedTable.r
+++ b/R/DocumentedTable.r
@@ -427,6 +427,13 @@ setValidity("DocumentedTable", function(object) {
   # Everything was okay, so we return TRUE:
   return(TRUE)
 })
+
+# It is useful for objects of this class to show compactly, instead of vomiting out the result of show() on each
+# of its slots:
+setMethod("show", "DocumentedTable", function(object) {
+  cat(paste("A DocumentedTable object named",name(object),"containing",length(tableColumns(object)),"columns."))
+})
+
 # Define setter and getter methods: (I hate how un-DRY this code is... Might be possible to just do this with some fancy meta-programming?)
 setGeneric("description", function(x) standardGeneric("description"))
 setGeneric("description<-", function(x, value) standardGeneric("description<-"))

--- a/R/SCB.r
+++ b/R/SCB.r
@@ -53,7 +53,7 @@ SCB <- function(verbose = FALSE, forceTable = NA_character_, failIfUnable = FALS
   if (!is.character(forceTable)) {
     stop("forceTable must be character.")
   }
-  if (!is.na(forceTable)) { # Note that we do not use missing() here, because vectorSCB needs to be able to pass NA explicitly to mark omission of the argument.
+  if (!missing(forceTable)) {
     # First, we check that the value of forceTable is actually the name of a table:
     if(!(forceTable %in% loadedTableNames)) {
       stop(paste(forceTable,"is not the name of a table."))

--- a/R/vectorSCB.r
+++ b/R/vectorSCB.r
@@ -1,3 +1,113 @@
+# The way it works is similar to normal queries -- each table implements vectorised queries against itself, and has a method
+# to check if a vectorised query can be run against it. The function vectorSCB itself just figures out which table to run
+# the query against and passes it to the right table.
+
+# Define canHandleQuery:
+setGeneric("canHandleVectorQuery", function(x, vectorColumn, ...) standardGeneric("canHandleVectorQuery"))
+setMethod("canHandleVectorQuery", "DocumentedTable", function(x, vectorColumn, ...) {
+  # First we pull out the names of the arguments we got: (Note that "list(...)" evaluates all the arguments. Right now
+  # we don't care about this, but this does prevent us from doing metaprogramming dark magics to the stuff in list(...))
+  argumentNames = names(list(...))
+
+  # If it wasn't already on it, we append the vectorColumn to the list of argument names:
+  if (!(vectorColumn %in% argumentNames)) {
+    # We need to record that we didn't receive a list of values for the vectorColumn:
+    vectorColumnValuesGiven <- FALSE
+    argumentNames[[length(argumentNames) + 1]] <- vectorColumn
+  } else {
+    vectorColumnValuesGiven <- TRUE
+  }
+
+  # Then we check that we can dealias each of these to a proper column name:
+  dealiasedArgumentNames <- columnDealias(x, argumentNames)
+  if (length(dealiasedArgumentNames) != length(argumentNames)) {
+    # At least one argument name failed to dealias, so we don't know what to do with this, and
+    # we return FALSE to indicate the table cannot handle this query:
+    return(FALSE)
+  }
+
+  # So we know all the column names we were given are real. If we weren't given a list of values for the vectorColumn,
+  # we need to explicitly add the empty list there:
+  argumentValues <- list(...)
+  if (!vectorColumnValuesGiven) {
+    argumentValues[[vectorColumn]] <- numeric(0)
+  }
+
+  # Time to check that each argument value corresponds to a (potential) level of that column:
+
+  for (argumentName in argumentNames) {
+    #TODO: This is a really bad algorithm, since it double loops, once over argumentNames and once over the columns
+    # per argumentName. Should figure out a way to do this with a single loop? Might not be a huge issue as long as
+    # we only have like ten columns, though.
+    argumentValue <- argumentValues[[argumentName]]
+    for (column in x@tableColumns) {
+      # If this column is the one that the argument name refers to...
+      if (name(column) == columnDealias(x,argumentName)) {
+        # ... we try to dealias the value of the argument against this column...
+        dealiasedArgumentValue <- levelDealias(column, argumentValue)
+        if (length(dealiasedArgumentValue) != length(argumentValue)) {
+          # ... and if at least one of the elements of argumentValue failed to dealias against
+          # this column, we conclude that while the column name matches the parameter we were
+          # passed, we are nonetheless not in the right table, since an invalid level was asked for.
+          # Perhaps there is some other table with the same column name that can handle this? We,
+          # however, return FALSE:
+          return(FALSE)
+        }
+      }
+    }
+  }
+
+  return(TRUE)
+})
+
+# Define the vectorQuery method for a single table:
+setGeneric("vectorQuery", function(x, vectorColumn, verbose=NA, checkHandleable=NA, failIfUnable=NA, ...) standardGeneric("vectorQuery"))
+setMethod("vectorQuery", "DocumentedTable", function(x, vectorColumn, verbose=FALSE, checkHandleable=TRUE, failIfUnable=FALSE, ...) {
+  # First we might need to check that we can handle this query:
+  if (checkHandleable) {
+    if (!canHandleVectorQuery(x, vectorColumn = vectorColumn, ...)) {
+      if (failIfUnable) {
+        stop("Table is unable to handle your query.")
+      } else {
+        warning("Table is unable to handle your query. Returning NA.")
+        return(NA)
+      }
+    }
+  }
+
+  # Let's store our user input in a better variable than ...: (And also force them all to be evaluated.)
+  passedParameters <- list(...)
+
+  # Second, we need to determine what levels of the vectorColumn to vector over:
+  if (vectorColumn %in% names(passedParameters)) {
+    # The user passed us a list of things to vector over in the "...". We move that over to its own special variable,
+    # and remove it from passedParameters:
+    levelsToVectorOver <- passedParameters[[vectorColumn]]
+    passedParameters[[vectorColumn]] <- NULL
+  } else {
+    # We did not get an explicit list of things to vector over, so we assume we should vector over all levels of the column.
+    # First dealias the name of the vectorColumn:
+    dealiasedVectorColumn <- columnDealias(x, vectorColumn)
+    levelsToVectorOver <- sort(unique(x@csvData[, dealiasedVectorColumn]))
+  }
+
+  # Having determined what to vector over, it is time to actually find the data the user wants:
+
+  queryResults <- sapply(levelsToVectorOver, function(level) {
+    # What we need to do is construct our query to query() and then call it using do.call:
+    callArguments <- list(...)
+    callArguments[[vectorColumn]] <- level
+    callArguments$checkHandleable <- FALSE
+    callArguments$verbose <- verbose
+    callArguments$x <- x
+
+    do.call("query", callArguments)
+  })
+  # Then we attach the right names to the result and hand it back to the user:
+  names(queryResults) <- levelsToVectorOver
+  return(queryResults)
+})
+
 #' Vectorise a call to SCB
 #'
 #' This function provides vectorisation of the SCB function -- it is effectively equivalent
@@ -13,8 +123,9 @@
 #' The verbose parameter still exists, with the same effect, but failIfUnable and errorHandlingMode are not supported.
 #'
 #' @param vectorColumn Which column should be vectorised over. This argument should not be quoted, just write it straight up. See examples.
-#' @param verbose Causes some extra messages to be printed explaining what is happening in the calls to downstream functions.
+#' @param verbose Causes some extra messages to be printed explaining what is happening. If you are getting unexpected results, try setting this to TRUE first.
 #' @param forceTable Directs the query to a specific table, in case your query does not uniquely determine a table.
+#' @param failIfUnable If the query cannot be handled by our tables, should we throw an error, or just a warning and return NA? TRUE gives errors, FALSE gives warnings.
 #' @param ... Your query, see documentation of SCB() for syntax for this.
 #'
 #' @seealso SCB
@@ -34,7 +145,7 @@
 #'
 #' @export
 
-vectorSCB <- function(vectorColumn, verbose=FALSE, forceTable = NA_character_, ...) {
+vectorSCB <- function(vectorColumn, verbose=FALSE, forceTable = NA_character_, failIfUnable = FALSE, ...) {
   # First off, let us validate the input types:
   if (!missing(verbose)) {
     if (!is.logical(verbose)) {
@@ -62,85 +173,55 @@ vectorSCB <- function(vectorColumn, verbose=FALSE, forceTable = NA_character_, .
     stop("You appear to have passed a complicated expression into vectorColumn. This is not evaluated -- if you want your arguments evaluated, use the !! operator provided by library rlang.")
   }
 
-  # Next up, we need to figure out what levels of this column we are to vectorise over. There are
-  # two cases -- either the user provided this list, or they expect to vectorise over all possible
-  # values:
-  levelsToVector <- list()
-  if (vectorColumnName %in% names(list(...))) {
-    # So the user provided this parameter, and our life is easy:
-    levelsToVector <- list(...)[[vectorColumnName]]
+  # Okay, so now we have the name of the column we want to vectorise over, so we are ready to figure out which table(s) can handle this query:
 
-    # We could do some error handling here, checking whether the column and levels the user specified actually exist. But that is handled
-    # by SCB() when we call it, so we let it handle that check.
-  } else {
-    # The user did not provide an explicit list of values to vector over. Again, there are two cases:
-    # If the user provided a forceTable, then we know which table to look for the levels of the column in.
-    # If not, we need to figure out which tables can handle our query.
-    if (!missing(forceTable)) {
-      # First, is the forceTable a real table?
-      if (!(forceTable %in% loadedTableNames)) {
-        stop(paste("Value ",forceTable," of forceTable does not match any existing table.",sep=""))
+  if (!missing(forceTable)) {
+    # First, we check that the value of forceTable is actually the name of a table:
+    if(!(forceTable %in% loadedTableNames)) {
+      stop(paste(forceTable,"is not the name of a table."))
+    }
+    # We check that the table asked for can actually handle the query:
+    if(!canHandleVectorQuery(allLoadedTables[[which(loadedTableNames == forceTable)]], vectorColumn = vectorColumnName, ...)) {
+      # If it can't, we either throw an error or return NA with a warning, depending on the value of failIfUnable:
+      if (failIfUnable) {
+        stop("The table that the query was forced to via forceTable is unable to handle the query.")
+      } else {
+        warning("The table that the query was forced to via forceTable is unable to handle the query. Returning NA.")
+        return(NA_real_)
       }
-      # Okay, so it is real... Does it actually have the requested column?
-      dealiasedVectorColumnName <- columnDealias(allLoadedTables[[which(loadedTableNames == forceTable)]], vectorColumnName)
-      if (is.null(dealiasedVectorColumnName)) {
-        stop(paste("vectorColumn set to ",vectorColumnName,", which is not a column in table ",forceTable,", which query was forced to via forceTable.",sep=""))
-      }
-      # So it has the requested column. Time to fetch the levels of said column:
-      levelsToVector <- sort(unique(csvData(allLoadedTables[[which(loadedTableNames == forceTable)]])[, dealiasedVectorColumnName]))
     } else {
-      # So we don't get a forceTable, and have to figure it out ourselves. The way to do this is of course to ask each table if it is able
-      # to handle a request involving both the values in ... and vectorColumn.
-      tablesAbleToRespond <- list()
-      for (candidateTable in allLoadedTables) {
-        # First, we need to set up the arguments we'll want to use:
-        callArguments <- list(...)
-        # When we supply an empty list, we still get a check that the column is present, but no checks that we supplied the right type of empty list:
-        callArguments[[vectorColumnName]] <- character()
-        # We also need to supply the table itself as an argument to canHandleQuery:
-        callArguments[["x"]] <- candidateTable
-        # Now we check if the table can handle the query. Unfortunately we can't write this as just a call to canHandleQuery with argument callArguments,
-        # we need to use do.call:
-        if(do.call("canHandleQuery", callArguments)) {
-          tablesAbleToRespond[[length(tablesAbleToRespond) + 1]] <- candidateTable
-        }
-      }
-      # If more than one table can handle the query, we throw an error, since we haven't implemented collision handling for this function.
-      #TODO: Implement collision handling for this function.
-      if (length(tablesAbleToRespond) > 1) {
-        # Just to be nice, we give the user a list of which tables were able to handle the query:
-        namesOfRespondingTables <- sapply(tablesAbleToRespond, name)
-        stop(paste("More than one table was able to handle your query, specifically the following:\n",
-                   paste(namesOfRespondingTables, collapse=", "),".\n"
-                   ,"Please use forceTable to specify which table to query."),sep="")
-      }
-      # Likewise, if no table is able to respond, we throw an error:
-      #TODO: Implement failIfUnable parameter for this function.
-      if (length(tablesAbleToRespond) == 0) {
-        stop("No table was able to handle your query. Have you misspelled a column or level name?")
-      }
+      # So it can handle the query, and we just pass this off straight to that table. It doesn't need to recheck
+      # if it can handle the query, since we already did that for it.
+      return(vectorQuery(allLoadedTables[[which(loadedTableNames == forceTable)]],
+                         vectorColumn = vectorColumnName, checkHandleable = FALSE, verbose = verbose, ...))
+    }
+  } else { #forceTable is missing:
+    # This should be the more common case -- we first need to figure out what table to send the query to, and then
+    # do it. The first part can be done in one line with a judicious use of sapply:
+    tablesAbleToHandleQuery <- which(sapply(allLoadedTables, function(tab) canHandleVectorQuery(tab, vectorColumn = vectorColumnName, ...)))
 
-      # So there is exactly one table able to handle this query, and now we can fetch the levels of the sought-after column:
-      dealiasedVectorColumnName <- columnDealias(tablesAbleToRespond[[1]], vectorColumnName)
-      levelsToVector <- sort(unique(csvData(tablesAbleToRespond[[1]])[, dealiasedVectorColumnName]))
-
-      # Since we know which table is supposed to be handling the query, we can just set forceTable now to simplify the job
-      # for SCB():
-      forceTable <- name(tablesAbleToRespond[[1]])
+    # Now we have a trilemma: Are zero, one, or more tables able to handle the query?
+    if (length(tablesAbleToHandleQuery) == 0) {
+      # So we can't handle the query. What to do depends on failIfUnable:
+      if (failIfUnable) {
+        stop("No table is able to handle your query -- have you misspelled a column or level?")
+      } else {
+        warning("No table is able to handle your query -- have you misspelled a column or level? Returning NA.")
+        return(NA_real_)
+      }
+    } else if (length(tablesAbleToHandleQuery) == 1) {
+      # This is the easiest case -- there's precisely one table able to handle the request.
+      if (verbose) {
+        # When verbose, we tell the user which table the data comes from:
+        message(paste("Query matched table ",loadedTableNames[tablesAbleToHandleQuery],". Returning data from said table.",sep=""))
+      }
+      # we run the query against the table and return the result:
+      return(vectorQuery(allLoadedTables[[tablesAbleToHandleQuery]], vectorColumn = vectorColumnName, checkHandleable = FALSE, verbose = verbose, ...))
+    } else if (length(tablesAbleToHandleQuery) > 1) {
+      # Unlike plain SCB(), our job here is simple, since we have no collision handling modes. We just throw an error.
+      stop(paste("Multiple tables are able to handle your request: ",paste(loadedTableNames[tablesAbleToHandleQuery], collapse=", "),".\n
+                   You can get around this error either by using forceTable to specify which of these tables to query, or by choosing a
+                   different collisionHandlingMode than \"error\".",sep=""))
     }
   }
-
-  # So we finally have the list of levels over which to vector. Time to actually do the vectoring -- at this point we can
-  # actually just do a sapply, although with a slightly more complicated function inside the sapply than usual:
-  queryResults <- sapply(levelsToVector, function(level) {
-    # What we need to do is construct our query to SCB() and then call it using do.call:
-    callArguments <- list(...)
-    callArguments[[vectorColumnName]] <- level
-    callArguments$forceTable <- forceTable
-    callArguments$verbose <- verbose
-    do.call("SCB", callArguments)
-  })
-  # Then we attach the right names to the result and hand it back to the user:
-  names(queryResults) <- levelsToVector
-  return(queryResults)
 }

--- a/R/vectorSCB.r
+++ b/R/vectorSCB.r
@@ -146,10 +146,8 @@ setMethod("vectorQuery", "DocumentedTable", function(x, vectorColumn, verbose=FA
 #' Vectorise a call to SCB
 #'
 #' This function provides vectorisation of the SCB function -- it is effectively equivalent
-#' to just doing it yourself with an sapply call, but makes for slightly neater code. Plus, there
-#' are some cases where this is not easy to do with a sapply -- implementing this function in full
-#' generality requires a bit of metaprogramming, which one probably doesn't want to do when writing
-#' a script...
+#' to just doing it yourself with an sapply call, but it is considerably faster, since it doesn't have
+#' to run query() once per level you're vectorising over.
 #' It is called precisely like \code{SCB()} for the query, but its other parameters are different.
 #' The central one is vectorColumn which should be set to the name of a column. The function then looks at whether you
 #' provided a list of values for that column: If you did, the function runs your query on each of those values, otherwise,

--- a/R/vectorSCB.r
+++ b/R/vectorSCB.r
@@ -116,11 +116,10 @@ setMethod("vectorQuery", "DocumentedTable", function(x, vectorColumn, verbose=FA
 #' generality requires a bit of metaprogramming, which one probably doesn't want to do when writing
 #' a script...
 #' It is called precisely like \code{SCB()} for the query, but its other parameters are different.
-#' The central one is vectorColumn which should be set to the name of a column. The function then looks at if you
-#' provided a list of values for that column: If you did, the function runs SCB() on each of those values, otherwise,
-#' if you omitted that column, it looks up what all of its possible values are, and vectorises over
-#' those.
-#' The verbose parameter still exists, with the same effect, but failIfUnable and errorHandlingMode are not supported.
+#' The central one is vectorColumn which should be set to the name of a column. The function then looks at whether you
+#' provided a list of values for that column: If you did, the function runs your query on each of those values, otherwise,
+#' if you omitted that column, it looks up what all of its possible values are, and vectorises over those.
+#' The verbose and failIfUnable parameters still exist, with the same effect, but collisionHandlingMode is not supported.
 #'
 #' @param vectorColumn Which column should be vectorised over. This argument should not be quoted, just write it straight up. See examples.
 #' @param verbose Causes some extra messages to be printed explaining what is happening. If you are getting unexpected results, try setting this to TRUE first.

--- a/man/vectorSCB.Rd
+++ b/man/vectorSCB.Rd
@@ -28,10 +28,8 @@ A named vector whose elements are results from SCB() and names are the level of 
 }
 \description{
 This function provides vectorisation of the SCB function -- it is effectively equivalent
-to just doing it yourself with an sapply call, but makes for slightly neater code. Plus, there
-are some cases where this is not easy to do with a sapply -- implementing this function in full
-generality requires a bit of metaprogramming, which one probably doesn't want to do when writing
-a script...
+to just doing it yourself with an sapply call, but it is considerably faster, since it doesn't have
+to run query() once per level you're vectorising over.
 It is called precisely like \code{SCB()} for the query, but its other parameters are different.
 The central one is vectorColumn which should be set to the name of a column. The function then looks at whether you
 provided a list of values for that column: If you did, the function runs your query on each of those values, otherwise,

--- a/man/vectorSCB.Rd
+++ b/man/vectorSCB.Rd
@@ -4,14 +4,22 @@
 \alias{vectorSCB}
 \title{Vectorise a call to SCB}
 \usage{
-vectorSCB(vectorColumn, verbose = FALSE, forceTable = NA_character_, ...)
+vectorSCB(
+  vectorColumn,
+  verbose = FALSE,
+  forceTable = NA_character_,
+  failIfUnable = FALSE,
+  ...
+)
 }
 \arguments{
 \item{vectorColumn}{Which column should be vectorised over. This argument should not be quoted, just write it straight up. See examples.}
 
-\item{verbose}{Causes some extra messages to be printed explaining what is happening in the calls to downstream functions.}
+\item{verbose}{Causes some extra messages to be printed explaining what is happening. If you are getting unexpected results, try setting this to TRUE first.}
 
 \item{forceTable}{Directs the query to a specific table, in case your query does not uniquely determine a table.}
+
+\item{failIfUnable}{If the query cannot be handled by our tables, should we throw an error, or just a warning and return NA? TRUE gives errors, FALSE gives warnings.}
 
 \item{...}{Your query, see documentation of SCB() for syntax for this.}
 }

--- a/man/vectorSCB.Rd
+++ b/man/vectorSCB.Rd
@@ -33,11 +33,10 @@ are some cases where this is not easy to do with a sapply -- implementing this f
 generality requires a bit of metaprogramming, which one probably doesn't want to do when writing
 a script...
 It is called precisely like \code{SCB()} for the query, but its other parameters are different.
-The central one is vectorColumn which should be set to the name of a column. The function then looks at if you
-provided a list of values for that column: If you did, the function runs SCB() on each of those values, otherwise,
-if you omitted that column, it looks up what all of its possible values are, and vectorises over
-those.
-The verbose parameter still exists, with the same effect, but failIfUnable and errorHandlingMode are not supported.
+The central one is vectorColumn which should be set to the name of a column. The function then looks at whether you
+provided a list of values for that column: If you did, the function runs your query on each of those values, otherwise,
+if you omitted that column, it looks up what all of its possible values are, and vectorises over those.
+The verbose and failIfUnable parameters still exist, with the same effect, but collisionHandlingMode is not supported.
 }
 \examples{
 # How much forest is there in each municipality in Sweden?:

--- a/tests/testthat/_snaps/vectorSCB.md
+++ b/tests/testthat/_snaps/vectorSCB.md
@@ -38,6 +38,8 @@
 
     Code
       vectorSCB(vectorColumn = LandUseType, Municipality = "Ludvika", verbose = TRUE)
+    Message <simpleMessage>
+      Query matched table LandUse. Returning data from said table.
     Output
       bebyggd mark och tillhörande mark                         betesmark 
                                    4774                               226 

--- a/tests/testthat/test-DocumentedTable.r
+++ b/tests/testthat/test-DocumentedTable.r
@@ -461,7 +461,7 @@ test_that("Setters and getters of DocumentedTable work", {
 
 # Next up, we test the columnDealias method:
 test_that("columnDealias works", {
-  # First we test a few things against the correctly formatted table:
+  # First we test the default mode, returning the name, against the correctly formatted table:
   expect_identical(columnDealias(tdt, "MunicipalitiesColumn"), "municipalities_column")
   expect_identical(columnDealias(tdt, c("MunicipalitiesColumn", "municipalities_column")),
                    c("municipalities_column", "municipalities_column"))
@@ -470,6 +470,17 @@ test_that("columnDealias works", {
   expect_null(columnDealias(tdt, "another_column_name"))
   expect_identical(columnDealias(tdt, c("MunicipalitiesColumn", "misplaced_column_name", "municipalities_column")),
                    c("municipalities_column", "municipalities_column"))
+
+  # Then we test the mode where getColumn=TRUE, so we expect to get the column objects themselves back:
+  expect_identical(columnDealias(tdt, "MunicipalitiesColumn", getColumn = TRUE), list(tcol_municip))
+  expect_identical(columnDealias(tdt, c("MunicipalitiesColumn", "municipalities_column"), getColumn = TRUE),
+                   list(tcol_municip, tcol_municip))
+  expect_identical(columnDealias(tdt, c("MunicipalitiesColumn", "character.column"), getColumn = TRUE),
+                   list(tcol_municip, tcol_char))
+  expect_null(columnDealias(tdt, "another_column_name", getColumn = TRUE))
+  expect_identical(columnDealias(tdt, c("MunicipalitiesColumn", "misplaced_column_name", "municipalities_column"), getColumn = TRUE),
+                   list(tcol_municip, tcol_municip))
+
   # Then, we make sure that if two columns share an alias, we get an error trying to dealias that alias:
   aliases(tdt@tableColumns[[1]]) <- c("numericColumn", "NumericColumn", "numeric.column","municipalities_column")
   expect_error(columnDealias(tdt,"municipalities_column"))

--- a/tests/testthat/test-vectorSCB.r
+++ b/tests/testthat/test-vectorSCB.r
@@ -16,12 +16,17 @@ test_that("Input validation of vectorSCB works", {
 
   # If we pass an argument to forceTable, it should be the name of a real table:
   expect_error(vectorSCB(vectorColumn=Age, forceTable="Not a real table name"))
-  # If we pass an argument to forceTable, the vectorColumn we passed should be in that table:
-  expect_error(vectorSCB(forceTable = "AgeGender", vectorColumn=NotARealColumn))
+  # If we pass an argument to forceTable, the vectorColumn we passed should be in that table. Whether we
+  # get an error or just a warning depends on the value of failIfUnable:
+  expect_error(vectorSCB(forceTable = "AgeGender", vectorColumn=NotARealColumn, failIfUnable = TRUE))
+  expect_warning(expect_identical(vectorSCB(forceTable = "AgeGender", vectorColumn=NotARealColumn, failIfUnable = FALSE), NA_real_))
 
-  # If we do not pass an argument to forceTable, our query has to actually be possible in some table:
-  expect_error(vectorSCB(vectorColumn=NotARealColumn, Age=25, Municipality="Ludvika"))
-  expect_error(vectorSCB(vectorColumn=Age, NotARealColumn=25, Municipality="Ludvika"))
+  # If we do not pass an argument to forceTable, our query has to actually be possible in some table. Whether we
+  # get an error or just a warning depends on the value of failIfUnable:
+  expect_error(vectorSCB(vectorColumn=NotARealColumn, Age=25, Municipality="Ludvika", failIfUnable = TRUE))
+  expect_warning(expect_identical(vectorSCB(vectorColumn=NotARealColumn, Age=25, Municipality="Ludvika", failIfUnable = FALSE), NA_real_))
+  expect_error(vectorSCB(vectorColumn=Age, NotARealColumn=25, Municipality="Ludvika", failIfUnable = TRUE))
+  expect_warning(expect_identical(vectorSCB(vectorColumn=Age, NotARealColumn=25, Municipality="Ludvika", failIfUnable = FALSE), NA_real_))
 
   # If our query works in multiple tables, we expect an error, since there is no collisionHandlingMode implemented yet:
   expect_error(vectorSCB(vectorColumn=Municipality))


### PR DESCRIPTION
This PR includes two refactorings: One improves the structure of vectorSCB, moving some of what it does into methods of the DocumentedTable class, which makes a lot more sense as a structural choice. The second vastly improves the performance of vectorSCB -- from taking more than a minute to run in the examples, it now takes about 1.2 seconds.